### PR TITLE
fixing output indentation

### DIFF
--- a/lib/ect.js
+++ b/lib/ect.js
@@ -51,6 +51,8 @@
 			regExpEscape = function (str) {
 				return String(str).replace(/([.*+?\^=!:${}()|\[\]\/\\])/g, '\\$1');
 			},
+			outputIndentationPrefix = '.replace(/\\n$/, \'\').replace(/\\n/g, \'\\n',
+			outputIndentationPostfix = '\') + \'\\n\'',
 
 			parse = function (template) {
 				var
@@ -58,7 +60,7 @@
 					bufferStack = [ '__ectOutput' ], bufferStackPointer = 0,
 					buffer = bufferStack[bufferStackPointer] + ' = \'',
 					matches = template.split(new RegExp(regExpEscape(ect.options.open) + '((?:.|[\r\n])+?)(?:' + regExpEscape(ect.options.close) + '|$)')),
-					output, text, command, line,
+					output, outputIndentation = '', text, command, line,
 					prefix, postfix, newline,
 					indentChar, indentation = '', indent = false, indentStack = [], indentStackPointer = -1, baseIndent, lines, j;
 
@@ -113,6 +115,7 @@
 								prefix = '\' + (' + line + '\n\'\') + (';
 								postfix = ') + \'';
 							}
+							text = '(' + text + ')' + outputIndentationPrefix + outputIndentation + outputIndentationPostfix;
 							buffer += prefix.replace(newlineExp, '\n' + indentation) + text + postfix.replace(newlineExp, '\n' + indentation);
 							break;
 						case 'block' :
@@ -133,9 +136,12 @@
 								prefix = '\' + (' + line + '\n\'\') + (';
 								postfix = ') + \'';
 							}
-							if (text === 'content') {
-								text = 'content()'
+							if (text === 'content' || text === 'content()') {
+								text = 'content(';
+							} else {
+								text = text.replace('content', 'content(');
 							}
+							text = text + ')' + outputIndentationPrefix + outputIndentation + outputIndentationPostfix;
 							buffer += prefix.replace(newlineExp, '\n' + indentation) + text + postfix.replace(newlineExp, '\n' + indentation);
 							break;
 						case 'end' :
@@ -254,6 +260,7 @@
 							break;
 						}
 					} else {
+						outputIndentation = text.match(/[ \t]*$/);
 						if (indentStack[indentStackPointer] !== 'switch') {
 							buffer += text.replace(/[\\']/g, '\\$&').replace(/\r/g, '').replace(newlineExp, '\\n').replace(/^\\n/, '');
 						}

--- a/lib/ect.js
+++ b/lib/ect.js
@@ -51,8 +51,8 @@
 			regExpEscape = function (str) {
 				return String(str).replace(/([.*+?\^=!:${}()|\[\]\/\\])/g, '\\$1');
 			},
-			outputIndentationPrefix = '.replace(/\\n$/, \'\').replace(/\\n/g, \'\\n',
-			outputIndentationPostfix = '\') + \'\\n\'',
+			outputIndentationPrefix = '.replace(/\\n(.)/g, \'\\n',
+			outputIndentationPostfix = '$1\')',
 
 			parse = function (template) {
 				var

--- a/lib/ect.js
+++ b/lib/ect.js
@@ -51,6 +51,7 @@
 			regExpEscape = function (str) {
 				return String(str).replace(/([.*+?\^=!:${}()|\[\]\/\\])/g, '\\$1');
 			},
+			outputIndentationExp = /[ \t]*$/,
 			outputIndentationPrefix = '.replace(/\\n(.)/g, \'\\n',
 			outputIndentationPostfix = '$1\')',
 
@@ -60,7 +61,7 @@
 					bufferStack = [ '__ectOutput' ], bufferStackPointer = 0,
 					buffer = bufferStack[bufferStackPointer] + ' = \'',
 					matches = template.split(new RegExp(regExpEscape(ect.options.open) + '((?:.|[\r\n])+?)(?:' + regExpEscape(ect.options.close) + '|$)')),
-					output, outputIndentation = '', text, command, line,
+					output, text, prevText, command, line,
 					prefix, postfix, newline,
 					indentChar, indentation = '', indent = false, indentStack = [], indentStackPointer = -1, baseIndent, lines, j;
 
@@ -115,7 +116,7 @@
 								prefix = '\' + (' + line + '\n\'\') + (';
 								postfix = ') + \'';
 							}
-							text = '(' + text + ')' + outputIndentationPrefix + outputIndentation + outputIndentationPostfix;
+							text = '(' + text + ')' + outputIndentationPrefix + prevText.match(outputIndentationExp) + outputIndentationPostfix;
 							buffer += prefix.replace(newlineExp, '\n' + indentation) + text + postfix.replace(newlineExp, '\n' + indentation);
 							break;
 						case 'block' :
@@ -141,7 +142,7 @@
 							} else {
 								text = text.replace('content', 'content(');
 							}
-							text = text + ')' + outputIndentationPrefix + outputIndentation + outputIndentationPostfix;
+							text = text + ')' + outputIndentationPrefix + prevText.match(outputIndentationExp) + outputIndentationPostfix;
 							buffer += prefix.replace(newlineExp, '\n' + indentation) + text + postfix.replace(newlineExp, '\n' + indentation);
 							break;
 						case 'end' :
@@ -260,7 +261,7 @@
 							break;
 						}
 					} else {
-						outputIndentation = text.match(/[ \t]*$/);
+						prevText = text;
 						if (indentStack[indentStackPointer] !== 'switch') {
 							buffer += text.replace(/[\\']/g, '\\$&').replace(/\r/g, '').replace(newlineExp, '\\n').replace(/^\\n/, '');
 						}


### PR DESCRIPTION
Taking the output formatting forward I made this:

``` html
<!DOCTYPE html>
<html>
    <head>
        <title>Hello, World!</title>
    </head>
    <body>
        <header>
            <h1>
    Page title line 1
    Page title line 2
</h1>
<h2>
    <span>Subtitle line 1</span>
<span>Subtitle line 2</span>
</h2>
        </header>
        <section>
            <div>
    <p>Page content line 1</p>
<p>Page content line 2</p>
</div>
        </section>
        <section>
            redefined side1 content line1
redefined side1 content line2
        </section>
        <section>
            side2 content line 1
side2 content line 2
        </section>
        <footer>
            <p>Footer content 1</p>
<p>Footer content 2</p>
        </footer>
    </body>
</html>
```

into this:

``` html
<!DOCTYPE html>
<html>
    <head>
        <title>Hello, World!</title>
    </head>
    <body>
        <header>
            <h1>
                Page title line 1
                Page title line 2
            </h1>
            <h2>
                <span>Subtitle line 1</span>
                <span>Subtitle line 2</span>
            </h2>
        </header>
        <section>
            <div>
                <p>Page content line 1</p>
                <p>Page content line 2</p>
            </div>
        </section>
        <section>
            redefined side1 content line1
            redefined side1 content line2
        </section>
        <section>
            side2 content line 1
            side2 content line 2
        </section>
        <footer>
            <p>Footer content 1</p>
            <p>Footer content 2</p>
        </footer>
    </body>
</html>
```

It works by prefixing each line in every `include`'s and `content`'s content with the original tag's indentation. This way one can author all the partials with 0 initial indentation and every command tag can be placed correctly in the document flow.
