### PR TITLE
Fix compiled version

### DIFF
--- a/lib/ect.js
+++ b/lib/ect.js
@@ -280,7 +280,7 @@
 			buffer += '\'\nif not __ectExtended\n  return __ectOutput\nelse\n  __ectContainer = __ectTemplateContext.load __ectParent\n  __ectFileInfo.file = __ectContainer.file\n  __ectFileInfo.line = 1\n  __ectTemplateContext.childContent = __ectOutput\n  return __ectContainer.compiled.call(this, __ectTemplateContext, __ectFileInfo, include, content, block)';
 			buffer = '__ectExtended = false\n' + buffer;
 
-			return eval('(function __ectTemplate(__ectTemplateContext, __ectFileInfo, include, content, block) {\n' + CoffeeScript.compile(buffer, { bare : true }) + '});');
+			return eval('(function __ectTemplate(__ectTemplateContext, __ectFileInfo, include, content, block) {\n' + CoffeeScript.compile(buffer, { bare : true }).toString() + '});');
 		};
 
 		var TemplateContext = function (data) {
@@ -332,9 +332,11 @@
 				}
 
 				data = read(file);
-				if (data.substr(0, 24) === '(function __ectTemplate(') {
+
+
+				if (data.substr(0, 23) === 'function __ectTemplate(') {
 					try {
-						compiled = eval(data);
+						compiled = eval("(" + data + ")");
 					} catch (e) {
 						e.message = e.message + ' in ' + file;
 						throw e;


### PR DESCRIPTION
- `CoffeeScript.compile` wasn't being parsed properly in the `eval`
- The compiled function, evaled did not include surrounding parenthesis.

Without this, I'm not sure this is supposed to work without CoffeeScript on the client.
