### PR TITLE
Wrong Content-length when Unicode compiled.templates are sent through XHR

### DIFF
--- a/lib/ect.js
+++ b/lib/ect.js
@@ -445,7 +445,7 @@
 									res.end(container.gzip);
 								}
 							} else {
-								res.setHeader('Content-Length', container.source.length);
+								res.setHeader('Content-Length', typeof Buffer !== "undefined" ? Buffer.byteLength(container.source, 'utf8') : container.source.length);
 								res.end(container.source);
 							}
 						} catch (e) {


### PR DESCRIPTION
The fix was easy, but important.

Try to view compiled template with for example this: "…" char (unicode) and after it have some numbers to see the results.
There will be missing last chars (ect wrappers).
