### PR TITLE
remove `.ect` suffix when call `res.render()` or in template `include` and `extend`

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ app.js
 var express = require('express');
 var app = express();
 var ECT = require('ect');
-var ectRenderer = ECT({ watch: true, root: __dirname + '/views' });
+var ectRenderer = ECT({ watch: true, root: __dirname + '/views', ext : '.ect' });
 
 app.set('view engine', 'ect');
 app.engine('ect', ectRenderer.render);

--- a/README.md
+++ b/README.md
@@ -82,8 +82,14 @@ console.log('Listening on port 3000');
 
 views/index.ect
 ```html
-<% extend 'layout.ect' %>
+<% extend 'layout' %>
+<% include 'extra' %>
 <div>Hello, World!</div>
+```
+
+views/extra.ect
+```html
+<div>Include me!</div>
 ```
 
 views/layout.ect

--- a/README.md
+++ b/README.md
@@ -69,10 +69,11 @@ var app = express();
 var ECT = require('ect');
 var ectRenderer = ECT({ watch: true, root: __dirname + '/views' });
 
-app.engine('.ect', ectRenderer.render);
+app.set('view engine', 'ect');
+app.engine('ect', ectRenderer.render);
 
 app.get('/', function (req, res){
-	res.render('index.ect');
+	res.render('index');
 });
 
 app.listen(3000);


### PR DESCRIPTION
when set `view engine` to `ect`, and engine app with `ectRenderer.render`.
we can remove the `.ect` suffix when call res.render(), just like using default view engine `ejs` and `jade`.
and remove `.ect` suffix in template `include` and `extend`
