### PR TITLE
this commit fixes #60

### DIFF
--- a/lib/ect.js
+++ b/lib/ect.js
@@ -1,5 +1,5 @@
 /*!
- * ECT CoffeeScript template engine v0.5.6
+ * ECT CoffeeScript template engine v0.5.7
  * https://github.com/baryshev/ect
  *
  * Copyright 2012-2013, Vadim M. Baryshev <vadimbaryshev@gmail.com>
@@ -404,7 +404,13 @@
 		};
 
 		this.render = function (template, data, callback) {
-			var context;
+			var context,
+				rootPath;
+			//set root in case it wasn't set to anything
+			//note assignment to rootPath
+			if (!this.options.root && (rootPath = path.dirname(template))) {
+				this.options.root = rootPath;
+			}
 			if (typeof arguments[arguments.length - 1] === 'function') {
 				if (arguments.length === 2) {
 					callback = data;


### PR DESCRIPTION
When root path not set we can still try to get it from first template passed into render function. Useful to make ect work with [koajs](http://koajs.com/) (through co-views) out of the box
