### PR TITLE
Redefined blocks now actually work as expected

### DIFF
--- a/lib/ect.js
+++ b/lib/ect.js
@@ -2,7 +2,7 @@
  * ECT CoffeeScript template engine v0.5.9
  * https://github.com/baryshev/ect
  *
- * Copyright 2012-2014, Vadim M. Baryshev <vadimbaryshev@gmail.com>
+ * Copyright 2012-2013, Vadim M. Baryshev <vadimbaryshev@gmail.com>
  * Licensed under the MIT license
  * https://github.com/baryshev/ect/LICENSE
  *
@@ -136,7 +136,7 @@
 							bufferStack.push('__ectTemplateContext.blocks[\'' + text.replace(/block\s+('|")([^'"]+)('|").*/, '$2') + '\']');
 							bufferStackPointer++;
 							prefix = '\'\n';
-							postfix = '\n' + bufferStack[bufferStackPointer] + ' += \'';
+							postfix = '\n' + bufferStack[bufferStackPointer] + ' = \'';
 							text = 'if ' + text;
 							buffer += prefix.replace(newlineExp, '\n' + indentation) + text;
 							if (indent) {
@@ -302,7 +302,7 @@
 
 		TemplateContext.prototype.block = function (name) {
 			if (!this.blocks[name]) { this.blocks[name] = ''; }
-			return !this.blocks[name].length;
+			return true || !this.blocks[name].length;
 		};
 
 		TemplateContext.prototype.content = function (block) {

--- a/lib/ect.js
+++ b/lib/ect.js
@@ -2,7 +2,7 @@
  * ECT CoffeeScript template engine v0.5.9
  * https://github.com/baryshev/ect
  *
- * Copyright 2012-2013, Vadim M. Baryshev <vadimbaryshev@gmail.com>
+ * Copyright 2012-2014, Vadim M. Baryshev <vadimbaryshev@gmail.com>
  * Licensed under the MIT license
  * https://github.com/baryshev/ect/LICENSE
  *


### PR DESCRIPTION
Fixes #79. I'm not 100% sure that this doesn't break anything but from my tests it seems to be fine. Would be great if someone who knows ECT could make this more elegant.

Basically makes this work as you would expect:

`base.ect`

``` html
<< block 'image' : >>
  <img src="111.png" />
<< end >>
<< include 'imageBox' >>
<< block 'image' : >>
  <img src="222.png" />
<< end >>
<< include 'imageBox' >>
```

`imageBox.ect`

``` html
<div class="imageBox">
  << content 'image' >>
</div>
```

The above example previously would compile both `<< include 'imageBox' >>` to only the first block content ( `111.png ).

I'd imagine something like this could be used to make #50 work as well without too much pain.
