### PR TITLE
Add webpack and ect-loader basic usage example on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,18 @@ Blocks supports more than one level of inheritance and may be redefined.
 
 ## Client-side support
 
+### Compiling within Webpack
+
+On your js file, require the template using [ect-loader](https://github.com/cusspvz/ect-loader)
+```js
+var body_template = require( 'ect-loader!./path/to/your/body_template.ect' )
+
+document.body.innerHtml = body_template( data )
+```
+For further usage info, read more about [ect-loader](https://github.com/cusspvz/ect-loader) and [webpack](https://webpack.github.io/docs/).
+
+### Compiling on Browser
+
 Download and include [coffee-script.js](https://github.com/jashkenas/coffee-script/blob/master/extras/coffee-script.js) and [ect.min.js](https://github.com/baryshev/ect/tree/master/ect.min.js).
 
 ```html
@@ -212,7 +224,7 @@ var data = { title : 'Hello, World!' };
 var html = renderer.render('template.ect', data);
 ```
 
-### With server side compiler middleware
+#### With server side compiler middleware
 
 Download and include [ect.min.js](https://github.com/baryshev/ect/tree/master/ect.min.js). You don't need to include CoffeeScript compiler, because templates are served already compiled by server side compiler middleware.
 


### PR DESCRIPTION
# [ect](http://ectjs.com/)-loader

[ect](http://ectjs.com/) templates compiler for webpack
## Motivation

[ectjs](http://ectjs.com/) is one of the fastest templating libraries out there,
but not so well known by the community.

As there wasn't a loader for webpack, I've decided to build one before going to
bed. Here it is, show your apretiation by starring the project, tweeting and
enjoy using it.
## Installation

```
npm i --save-dev ect-loader
```
## Usage

[Documentation: Using loaders](http://webpack.github.io/docs/using-loaders.html)
### Example config

This webpack config can compile ect templates for you to use on your browser
without having to load `ECT` and `CoffeeScript` browser versions.

``` javascript
module.exports = {
  module: {
    loaders: [
      { test: /\.ect$/, loader: "ect" }
    ]
  }
};
```
## Minification

This loader minifies template before compiling in case you're running with
performance enhancment option (`webpack -p`).

It works by cutting off spaces between **HTML tags** and line-breaks.
### Source Example

```
<div id="testing">
    <%- __ "Read the docs" %>
</div>
```
### Minified output

```
<div id="testing"> Lê a documentação </div>
```
